### PR TITLE
Add postinst script to kernel-image package

### DIFF
--- a/recipes-kernel/linux/linux-yocto-custom_3.10.bb
+++ b/recipes-kernel/linux/linux-yocto-custom_3.10.bb
@@ -59,3 +59,28 @@ SRC_URI += "file://tun_kmodule.cfg"
 # We use the AT91SAM9G20 so add that to the device trees built in
 KERNEL_DEVICETREE += "${S}/arch/arm/boot/dts/at91sam9g20ek.dts"
 
+pkg_postinst_kernel-image(){
+#!/bin/sh -e
+# Commands to carry out
+KERNEL_MTD=/dev/mtd3
+KERNEL_IMG=uImage-3.10.0-custom
+TESTPASSES=5
+
+die() {
+    logger -p daemon.emerg -t kernel-image-install -s $*
+    exit 1
+      }
+
+# Test NAND for bad blocks. Mark them bad if found. Run ${TESTPASSES} tests.
+nandtest -p ${TESTPASSES} -m ${KERNEL_MTD}
+
+# Erase flash which is required for the next steps
+flash_erase ${KERNEL_MTD} 0 0 || die "Failed to erase ${KERNEL_MTD}"
+
+# Program in kernel
+nandwrite -p ${KERNEL_MTD} /boot/${KERNEL_IMG} \
+    || die "Failed to write kernel to NAND"
+
+echo "The new kernel will be loaded at the next reboot."
+}
+

--- a/recipes-kernel/linux/linux-yocto-custom_3.10.bb
+++ b/recipes-kernel/linux/linux-yocto-custom_3.10.bb
@@ -71,6 +71,9 @@ die() {
     exit 1
       }
 
+# We only want this to run on the actual device
+[ "x${D}" != "x" ] || exit 1
+
 # Test NAND for bad blocks. Mark them bad if found. Run ${TESTPASSES} tests.
 nandtest -p ${TESTPASSES} -m ${KERNEL_MTD}
 

--- a/recipes-kernel/linux/linux-yocto-custom_3.10.bb
+++ b/recipes-kernel/linux/linux-yocto-custom_3.10.bb
@@ -63,7 +63,7 @@ pkg_postinst_kernel-image(){
 #!/bin/sh -e
 # Commands to carry out
 KERNEL_MTD=/dev/mtd3
-KERNEL_IMG=uImage-3.10.0-custom
+KERNEL_IMG=uImage-${KERNEL_VERSION}
 TESTPASSES=5
 
 die() {


### PR DESCRIPTION
This commit addes a custom postinst script to the kernel-image-<version> ipkg.
This commit required /dev/mtd3 to be mounted as RW and this modification to
the u-Boot args is not addressed in this commit.

This commit fixes ETEN-5.
