### PR TITLE
Added a line to cause bitbake to ignore the poky python-argparse

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -21,3 +21,4 @@ USE_NLS = "no"
 # Attempt to use python 2.7.9
 PREFERRED_VERSION_python ?= "2.7.9"
 PREFERRED_VERSION_python-native ?= "2.7.9"
+PREFERRED_PROVIDER_python-argparse ?= "python"


### PR DESCRIPTION
This is the right way to ignore poky's built in argparse.

@RonJolly 
