### PR TITLE
Fix typo - Did not have an sh suffix on the script file

### DIFF
--- a/recipes-extended/snap-enable/snap-enable_1.0.0.bb
+++ b/recipes-extended/snap-enable/snap-enable_1.0.0.bb
@@ -16,6 +16,6 @@ do_install() {
     install -m 0755 ${WORKDIR}/snap-enable.sh ${D}/etc/init.d/
 
     cd ${D}/etc/rcS.d/
-    ln -s ../init.d/snap-enable ./S95snap-enable
+    ln -s ../init.d/snap-enable.sh ./S95snap-enable
     cd -
 }


### PR DESCRIPTION
The link creation definition for the link from S95snap-enable should be snap-enable.sh
