### PR TITLE
Added code for logging to the lighting boot server during the upgrade

### DIFF
--- a/recipes-core/images/synapse-image-e10-rescue.bb
+++ b/recipes-core/images/synapse-image-e10-rescue.bb
@@ -1,5 +1,6 @@
 SUMMARY = "The rescue kernel + initramfs for the Connect E10"
 
+
 IMAGE_INSTALL = "packagegroup-core-boot ${ROOTFS_PKGMANAGE_BOOTSTRAP} ${CORE_IMAGE_EXTRA_INSTALL}"
 
 IMAGE_LINGUAS = " "

--- a/recipes-core/synapse-recovery/files/synapse-recovery.sh
+++ b/recipes-core/synapse-recovery/files/synapse-recovery.sh
@@ -3,19 +3,41 @@
 TESTPASSES=5
 RECOVERY_TAR=
 RECOVERY_MTD=/dev/mtd6
+
 ROOTFS_MTD=/dev/mtd5
 ROOTFS_UBI=rootfs-at91sam9x5ek.ubifs
+ROOTFS_NANDTEST_DATA="/tmp/nandtest.rootfs.log"
+
 KERNEL_MTD=/dev/mtd3
 KERNEL_IMG=uImage-at91sam9x5ek.bin
+KERNEL_NANDTEST_DATA="/tmp/nandtest.kernel.log"
+
 UBOOT_MTD=/dev/mtd1
 UBOOT_IMG=u-boot-at91sam9x5ek.bin
+UBOOT_NANDTEST_DATA="/tmp/nandtest.uboot.log"
+
 UBOOT_BOOTCMD="nboot 0x21000000 0 c0000"
 UBOOT_BOOTARGS="console=ttyS0,115200 mtdparts=atmel_nand:128K(bootstrap)ro,384K(uboot)ro,256K(environment),3328K(uImage),9216K(rescue)ro,211M(rootfs),-(recovery) ubi.mtd=rootfs root=ubi0:rootfs rw rootfstype=ubifs"
+
+# For snap-lighting
+BOOTSRVURL="http://boot-dev.snap-lighting.com"
+MACADDR=`cat /sys/class/net/eth0/address | cut -d : -f 4,5,6 | cut -c 1-2,4-5,7-8`
+LOGPATH="log/$MACADDR"
+CLEANEDLOG="/tmp/clean.log"
 
 die() {
     logger -p daemon.emerg -t synapse-recovery -s $*
     exit 1
 }
+
+log() {
+        msg="$*"
+        quotedMsg=`/usr/sbin/urlencode.sh $msg`
+        data1="$BOOTSRVURL/$LOGPATH --post-data message=$quotedMsg"
+        #echo "Data = [$data1]"
+        result="`wget -q -O - $data1 `"
+}
+
 
 while getopts m:t:p: name; do
 	case ${name} in
@@ -33,7 +55,7 @@ while getopts m:t:p: name; do
 done
 
 REBOOT=no
-
+log "SnapLighting Upgrade 1.x to 2.x - Entering Stage 2"
 # Verify recovery image
 
 # Extract recovery image
@@ -41,20 +63,39 @@ if [ ! -z ${RECOVERY_TAR} ]; then
 	tar zxf ${RECOVERY_TAR} -C /run/ \
 		|| die "Failed to extract kernel & rootfs from ${RECOVERY_TAR}"
 else
-	# This can fail because we don't know how big the file is and as a result
+            # This can fail because we don't know how big the file is and as a result
 	# we will get random bytes of the NAND at the end which will be run
 	# through xz -d first which can cause tar to lose its mind.
 	nanddump ${RECOVERY_MTD} 2>/dev/null | tar zvxf - -C /run/ 2>/dev/null
 	[ -e /run/md5sums ] || die "Failed to extract rootfs & kernel from NAND \
 		or no recovery data present"
 fi
+log "  SLU: Recovery image extracted"
+
 cd /run/ || die "Failed to cd to /run/"
 md5sum -c md5sums || die "Failed to validate md5sums"
 
 # if the recovery image contained a rootfs, load it
 if [ -e /run/${ROOTFS_URI} ]; then
+    log "  SLU: nandtest of rootfs partition starting"
     # Test NAND for bad blocks. Mark them bad if found. Run ${TESTPASSES} tests.
-    nandtest -p ${TESTPASSES} -m ${ROOTFS_MTD}
+    #nandtest -p ${TESTPASSES} -m ${ROOTFS_MTD}
+    touch "$ROOTFS_NANDTEST_DATA"
+    nandtest -p ${TESTPASSES} -m ${ROOTFS_MTD} 2>&1 | tee -a  ${ROOTFS_NANDTEST_DATA}
+
+    # Log the results
+    if [ -f "$ROOTFS_NANDTEST_DATA" ]; then
+        
+                # Clean up the output
+                 # Clean up the output
+                `cat $ROOTFS_NANDTEST_DATA | tr '\r' '\n' | grep -v 'checking\|reading\|writing\|erasing' | sed '/^\s*$/d' > $CLEANEDLOG`
+                
+                # Read in the file
+                logdata=`cat $CLEANEDLOG`
+                log "  SLU: nandtest of $ROOTFS_MTD (rootfs):\n$logdata"
+    else
+        echo "No Recovery Nandtest Data File Found: $ROOTFS_NANDTEST_DATA"
+    fi
 
     # Don't actually erase because that clears the erase counters
     # which is necessary to do proper wear leveling
@@ -73,7 +114,25 @@ fi
 # if the recovery image contained a rootfs, load it
 if [ -e /run/${KERNEL_IMG} ]; then
     # Test NAND for bad blocks. Mark them bad if found. Run ${TESTPASSES} tests.
-    nandtest -p ${TESTPASSES} -m ${KERNEL_MTD}
+    # nandtest -p ${TESTPASSES} -m ${KERNEL_MTD}
+     log "  SLU: nandtest of kernel partition starting"
+
+    touch "$KERNEL_NANDTEST_DATA"
+    nandtest -p ${TESTPASSES} -m ${KERNEL_MTD} 2>&1 | tee -a ${KERNEL_NANDTEST_DATA}
+
+    # Log the results
+    if [ -f "$KERNEL_NANDTEST_DATA" ]; then
+        
+                # Clean up the output
+                 # Clean up the output
+                `cat $KERNEL_NANDTEST_DATA | tr '\r' '\n' | grep -v 'checking\|reading\|writing\|erasing' | sed '/^\s*$/d' > $CLEANEDLOG`
+                
+                # Read in the file
+                logdata=`cat $CLEANEDLOG`
+                log "  SLU: nandtest of $KERNEL_MTD (kernel):\n$logdata"
+    else
+        echo "No Kernel Nandtest Data File Found: $KERNEL_NANDTEST_DATA"
+    fi
 
     # Erase flash which is required for the next steps
     flash_erase ${KERNEL_MTD} 0 0 || die "Failed to erase ${KERNEL_MTD}"
@@ -88,7 +147,25 @@ fi
 # if the recovery image contained U-Boot, load it
 if [ -e /run/${UBOOT_IMG} ]; then
     # Test NAND for bad blocks. Mark them bad if found. Run ${TESTPASSES} tests.
-    nandtest -p ${TESTPASSES} -m ${UBOOT_MTD}
+    # nandtest -p ${TESTPASSES} -m ${UBOOT_MTD}
+    touch "$UBOOT_NANDTEST_DATA"
+    log "  SLU: nandtest of uboot partition starting"
+
+    nandtest -p ${TESTPASSES} -m ${UBOOT_MTD} 2>&1 | tee -a  ${UBOOT_NANDTEST_DATA}
+
+    # Log the results
+    if [ -f "$UBOOT_NANDTEST_DATA" ]; then
+        
+                # Clean up the output
+                 # Clean up the output
+                `cat $UBOOT_NANDTEST_DATA | tr '\r' '\n' | grep -v 'checking\|reading\|writing\|erasing' | sed '/^\s*$/d' > $CLEANEDLOG`
+                
+                # Read in the file
+                logdata=`cat $CLEANEDLOG`
+                log "  SLU: nandtest of $UBOOT_MTD (uboot):\n$logdata"
+    else
+        echo "No Kernel Nandtest Data File Found: $KERNEL_NANDTEST_DATA"
+    fi
 
     # Erase flash which is required for the next steps
     flash_erase ${UBOOT_MTD} 0 0 || die "Failed to erase ${UBOOT_MTD}"
@@ -111,6 +188,7 @@ fw_setenv bootcmd ${UBOOT_BOOTCMD} || die "Failed to set u-boot bootcmd"
 
 fw_printenv
 
+log "SnapLighting Upgrade 1.x to 2.x - Leaving Stage 2, Rebooting Now."
 # Reboot
 if [ "x${REBOOT}" == "xyes" ]; then
 	# if we used the RECOVERY_MTD then we need to clear it out

--- a/recipes-core/synapse-recovery/files/urlencode.sh
+++ b/recipes-core/synapse-recovery/files/urlencode.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# A very primative URL string encoder that works within the limited
+# environment provided by the rescue image.
+
+
+
+# sed cmds to urlencode
+SEDCMDS='s:%:%25:g; s: :%20:g; s:<:%3C:g; s:>:%3E:g; s:#:%23:g; s:{:%7B:g; s:}:%7D:g; s:|:%7C:g; s:\\:%5C:g; s:\^:%5E:g; s:~:%7E:g; s:\[:%5B:g; s:\]:%5D:g; s:`:%60:g; s:;:%3B:g; s:/:%2F:g; s:?:%3F:g; s^:^%3A^g; s:@:%40:g; s:=:%3D:g; s:&:%26:g; s:\$:%24:g; s:\!:%21:g; s:\*:%2A:g; s:,:%2C:g; s:(:%28:g; s:):%29:g;'
+
+urlencode_sed() {
+        result=`echo "$*" | sed -e "$SEDCMDS"`
+        echo $result
+}
+[ $# -ge 1 ] && input="$*" || read input
+
+urlencode_sed "$input"

--- a/recipes-core/synapse-recovery/synapse-recovery_1.1.bb
+++ b/recipes-core/synapse-recovery/synapse-recovery_1.1.bb
@@ -1,19 +1,21 @@
 SUMMARY = "Synapse Recovery Scripts and Files"
 DESCRIPTION = "Scripts to recover from a Synapse Recovery image"
 SECTION = "base"
-PR = "r6"
+PR = "r7"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
                     file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
 SRC_URI = "file://synapse-recovery.sh \
-           file://synapse-recovery.init"
+           	file://synapse-recovery.init \
+           	file://urlencode.sh"
+
 S = "${WORKDIR}"
 
 inherit allarch update-rc.d
 
-INITSCRIPT_NAME = "synapse-recovery"
-INITSCRIPT_PARAMS = "start 99 S ."
+INITSCRIPT_NAME="synapse-recovery"
+INITSCRIPT_PARAMS="start 99 S ."
 
 do_configure() {
 	:
@@ -24,14 +26,24 @@ do_compile() {
 }
 
 do_install () {
-	# install synapse-recovery.sh into /usr/bin
+	# install synapse-recovery.sh into /usr/sbin as synapse-recovery
 	install -d ${D}${sbindir}
 	install -m 0755 ${S}/synapse-recovery.sh ${D}${sbindir}/synapse-recovery
 
+	# install urlencode.sh into /usr/bin
+	install -d ${D}${sbindir}
+	install -m 0755 ${S}/urlencode.sh ${D}${sbindir}/urlencode.sh
+
+	# install the init script into init.d, and link it into rc5.d
 	install -d ${D}${sysconfdir}/init.d/
-	install -m 0755 ${S}/synapse-recovery.init \
-		${D}${sysconfdir}/init.d/synapse-recovery
+	install -d ${D}${sysconfdir}/rc5.d/
+
+	install -m 0755 ${S}/synapse-recovery.init ${D}${sysconfdir}/init.d/synapse-recovery
+	ln -sf /etc/init.d/synapse-recovery ${D}${sysconfdir}/rc5.d/S99synapse-recovery
 }
 
+# add these files to the package
 FILES_${PN} = "${sbindir}/synapse-recovery \
-	           ${sysconfdir}/init.d/synapse-recovery"
+		${sbindir}/urlencode.sh \
+	           	${sysconfdir}/init.d/synapse-recovery \
+	           	${sysconfdir}/rc5.d/S99synapse-recovery"


### PR DESCRIPTION
The synapse-recovery.sh upgrade script now gets called AFTER networking
has been initialized.

Added simplistic URL encoder based on sed

Modified the recipe to install the urlencoder script into the rescue image.
